### PR TITLE
Add Google site verification meta tag to Docusaurus config

### DIFF
--- a/apps/huckleberry-docs/docusaurus.config.ts
+++ b/apps/huckleberry-docs/docusaurus.config.ts
@@ -35,6 +35,17 @@ const config: Config = {
     locales: ['en'],
   },
 
+  // Add Google site verification meta tag
+  headTags: [
+    {
+      tagName: 'meta',
+      attributes: {
+        name: 'google-site-verification',
+        content: 'vcXVoRYtK7tLGjvik4u-4h1xuwyYS77_uI4tjW8Xk1A',
+      },
+    },
+  ],
+
   presets: [
     [
       'classic',


### PR DESCRIPTION
Include a meta tag for Google site verification in the Docusaurus configuration to enhance site indexing.