### PR TITLE
Fix awk command for extracting changelog version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
           VERSION=${{ steps.package_version.outputs.version }}
           # Use awk to extract the content between the current version header and the next version header
           # This accounts for the date format in the CHANGELOG.md headers: "## x.y.z (date)"
-          CHANGES=$(awk -v version="## $VERSION" '
+          CHANGES=$(awk -v version="## $VERSION \\([0-9]{4}-[0-9]{2}-[0-9]{2}\\)" '
             BEGIN { found=0; content=""; }
             $0 ~ "^## " { 
               if (found == 1) { exit }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
           VERSION=${{ steps.package_version.outputs.version }}
           # Use awk to extract the content between the current version header and the next version header
           # This accounts for the date format in the CHANGELOG.md headers: "## x.y.z (date)"
-          CHANGES=$(awk -v version="## $VERSION \\(" '
+          CHANGES=$(awk -v version="## $VERSION" '
             BEGIN { found=0; content=""; }
             $0 ~ "^## " { 
               if (found == 1) { exit }


### PR DESCRIPTION
Correct the awk command to properly extract the content between version headers in the CHANGELOG.md file.