### PR TITLE
Improve clarity in examples of deterministic logic and LLM flexibility

### DIFF
--- a/apps/huckleberry-docs/blog/2025-04-24-finding-the-balance.md
+++ b/apps/huckleberry-docs/blog/2025-04-24-finding-the-balance.md
@@ -32,7 +32,7 @@ For example, managing task state in Huckleberry is deterministic. We want to kno
 Consider how Huckleberry handles task creation:
 
 1. **LLM Flexibility**: When a user types "I need to implement authentication for my API", the LLM interprets this intent and decides a task should be created
-2. **Deterministic Logic**: Once the decision is made, our code handles the creation process—generating an ID, timestamping, formatting the JSON, updating indexes
+2. **Deterministic Logic**: Once the decision is made, our code handles the creation process, generating an ID, timestamping, formatting the JSON, updating indexes
 3. **LLM Flexibility**: When suggesting related tasks or next steps, the LLM can consider the broader context of the project
 4. **Deterministic Logic**: The actual state changes and storage of these relationships follow strict rules
 

--- a/apps/huckleberry-docs/blog/2025-04-29-ux-is-the-new-code.md
+++ b/apps/huckleberry-docs/blog/2025-04-29-ux-is-the-new-code.md
@@ -110,7 +110,7 @@ Applying these patterns produces more reliable, target-specific outputs.
 
 ## Finding the Balance
 
-While AI tools like Huckleberry can help manage your development tasks and GitHub Copilot can generate functional code, the human touch remains essential for creating truly exceptional user experiences. The partnership between AI assistance and thoughtful UX design represents the future of software development—technically robust applications that also delight users.
+While AI tools like Huckleberry can help manage your development tasks and GitHub Copilot can generate functional code, the human touch remains essential for creating truly exceptional user experiences. The partnership between AI assistance and thoughtful UX design represents the future of software development, technically robust applications that also delight users.
 
 ## Further Reading
 


### PR DESCRIPTION
Enhance the clarity of examples related to deterministic logic and LLM flexibility in the documentation. Adjustments made to improve readability and flow.