### PR TITLE
Add option to exclude completed tasks in selection

### DIFF
--- a/apps/huckleberry-extension/src/extension.ts
+++ b/apps/huckleberry-extension/src/extension.ts
@@ -479,7 +479,7 @@ function markTaskComplete(taskId?: string): void {
           vscode.window.showErrorMessage('Extension not properly initialized');
           return;
         }
-        const selectedTaskId = await promptForTaskSelection(extensionState.toolManager);
+        const selectedTaskId = await promptForTaskSelection(extensionState.toolManager, true);
         if (selectedTaskId) {
           // Execute the command with the selected task ID
           vscode.commands.executeCommand(

--- a/apps/huckleberry-extension/src/utils/parameterUtils.ts
+++ b/apps/huckleberry-extension/src/utils/parameterUtils.ts
@@ -28,9 +28,10 @@ interface TaskSelectionResult {
 /**
  * Prompts the user to select a task
  * @param toolManager The tool manager instance
+ * @param excludeCompleted Whether to exclude completed tasks from the list
  * @returns A promise that resolves with the selected task ID or undefined if cancelled
  */
-export async function promptForTaskSelection(toolManager: ToolManager): Promise<string | undefined> {
+export async function promptForTaskSelection(toolManager: ToolManager, excludeCompleted = false): Promise<string | undefined> {
   try {
     // Get workspace paths
     const { tasksJsonPath } = await getWorkspacePaths();
@@ -44,8 +45,18 @@ export async function promptForTaskSelection(toolManager: ToolManager): Promise<
       return undefined;
     }
     
+    // Filter tasks if needed
+    const availableTasks = excludeCompleted 
+      ? tasksData.tasks.filter(task => !task.completed)
+      : tasksData.tasks;
+
+    if (excludeCompleted && availableTasks.length === 0) {
+      vscode.window.showInformationMessage('No incomplete tasks found. All tasks are completed!');
+      return undefined;
+    }
+    
     // Create quick pick items with task details
-    const items: TaskQuickPickItem[] = tasksData.tasks.map(task => {
+    const items: TaskQuickPickItem[] = availableTasks.map(task => {
       const priorityIcon = task.priority ? priorityEmoji[task.priority] || '⚪' : '⚪';
       return {
         label: `${task.id}`,


### PR DESCRIPTION
Introduce a feature that allows users to exclude completed tasks when selecting from the task list, enhancing task management efficiency.