### PR TITLE
chore(docs): add lint command to project configuration

### DIFF
--- a/apps/huckleberry-docs/project.json
+++ b/apps/huckleberry-docs/project.json
@@ -25,6 +25,12 @@
         "command": "docusaurus serve --dir=build",
         "cwd": "apps/huckleberry-docs"
       }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "echo 'No linting required for docs.'"
+      }
     }
   },
   "tags": ["docs"]


### PR DESCRIPTION
Introduces a lint command in the project configuration for documentation:
- Specifies that no linting is required for the documentation files.
- Ensures consistency in project setup and clarity for future contributors.