### PR TITLE
feat(extension): add typechecking capability for huckleberry extension

### DIFF
--- a/apps/huckleberry-docs/project.json
+++ b/apps/huckleberry-docs/project.json
@@ -32,6 +32,13 @@
         "command": "echo 'No linting required for docs.'"
       },
       "outputs": []
+    },
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "echo 'No typechecking required for docs.'"
+      },
+      "outputs": []
     }
   },
   "tags": ["docs"]

--- a/apps/huckleberry-extension/project.json
+++ b/apps/huckleberry-extension/project.json
@@ -40,6 +40,15 @@
         "cwd": "apps/huckleberry-extension",
         "command": "npm run lint"
       }
+    },
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "apps/huckleberry-extension",
+        "command": "sh -c 'tsc -p tsconfig.json --noEmit'"
+      },
+      "outputs": [],
+      "dependsOn": []
     }
   }
 }


### PR DESCRIPTION
Implements typechecking for the huckleberry extension to ensure code quality:
- Adds a typecheck target that runs TypeScript compiler without emitting files.
- Ensures that type errors are caught during development.

Closes #42