### PR TITLE
refactor(extension): simplify build command execution

### DIFF
--- a/apps/huckleberry-docs/project.json
+++ b/apps/huckleberry-docs/project.json
@@ -15,7 +15,7 @@
       "executor": "nx:run-commands",
       "outputs": ["{projectRoot}/build"],
       "options": {
-        "command": "docusaurus build",
+        "command": "sh -c 'docusaurus build'",
         "cwd": "apps/huckleberry-docs"
       }
     },

--- a/apps/huckleberry-extension/project.json
+++ b/apps/huckleberry-extension/project.json
@@ -9,9 +9,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "apps/huckleberry-extension",
-        "commands": [
-          "tsc -p tsconfig.json"
-        ],
+        "command": "sh -c 'tsc -p tsconfig.json'",
         "outputs": [
           "{projectRoot}/dist"
         ]


### PR DESCRIPTION
Updates the build command in the huckleberry extension to use a shell command for execution:
- Changes the command from a direct string to a shell command wrapped in 'sh -c'.
- Ensures consistency with other commands in the project.

No functional changes are introduced.